### PR TITLE
Fix assets not picking up properly on windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const HtmlPlugin = require('html-webpack-plugin')
 const { DefinePlugin, ProgressPlugin, optimize, ContextReplacementPlugin, NormalModuleReplacementPlugin } = require('webpack')
 const { AotPlugin } = require('@ngtools/webpack')
 
-const TEST_ASSETS = /assets\/.*\.scss$/;
+const TEST_ASSETS = /assets[\/\\].*\.scss$/;
 const OUTPUT_PATH = path.resolve(__dirname, 'dist')
 const SOURCE_PATH = path.resolve(__dirname, 'src')
 const STATS = {


### PR DESCRIPTION
I'm using windows with cygwin's bash as my primary shell in VS Code and for some reason webpack is using Windows path separators instead of Linux ones.

This small change fixes it.

There also is an issue with npm scripts on Windows, but I don't know how to fix it properly.